### PR TITLE
AVRO-2344: Enable to handle timestamp logical types corresponding to proto Timestamp

### DIFF
--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtoConversions.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtoConversions.java
@@ -1,0 +1,87 @@
+package org.apache.avro.protobuf;
+
+import com.google.protobuf.Timestamp;
+import org.apache.avro.Conversion;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+
+public class ProtoConversions {
+
+  public static class TimestampConversion extends Conversion<Timestamp> {
+    @Override
+    public Class<Timestamp> getConvertedType() {
+      return Timestamp.class;
+    }
+
+    @Override
+    public String getLogicalTypeName() {
+      return "timestamp-millis";
+    }
+
+    @Override
+    public Timestamp fromLong(Long millisFromEpoch, Schema schema, LogicalType type) {
+      java.sql.Timestamp ts = new java.sql.Timestamp(millisFromEpoch);
+
+      return Timestamp.newBuilder()
+        .setSeconds(ts.getTime() / 1000)
+        .setNanos(ts.getNanos())
+        .build();
+    }
+
+    @Override
+    public Long toLong(Timestamp value, Schema schema, LogicalType type) {
+      java.sql.Timestamp ts = new java.sql.Timestamp(value.getSeconds() * 1000);
+      ts.setNanos(value.getNanos());
+
+      return ts.getTime();
+    }
+
+    @Override
+    public Schema getRecommendedSchema() {
+      return LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
+    }
+  }
+
+  public static class TimestampMicrosConversion extends Conversion<Timestamp> {
+    @Override
+    public Class<Timestamp> getConvertedType() {
+      return Timestamp.class;
+    }
+
+    @Override
+    public String getLogicalTypeName() {
+      return "timestamp-micros";
+    }
+
+    @Override
+    public Timestamp fromLong(Long microsFromEpoch, Schema schema, LogicalType type) {
+      java.sql.Timestamp ts = new java.sql.Timestamp(microsFromEpoch / 1000);
+      int micros = (int) (microsFromEpoch - (microsFromEpoch / 1000000 * 1000000));
+      ts.setNanos(micros * 1000);
+
+      return Timestamp.newBuilder()
+        .setSeconds(ts.getTime() / 1000)
+        .setNanos(ts.getNanos())
+        .build();
+    }
+
+    @Override
+    public Long toLong(Timestamp value, Schema schema, LogicalType type) {
+      if (value.getNanos() - (value.getNanos() / 1000000 * 1000000) > 0) {
+        throw new UnsupportedOperationException("micros-precise is supported");
+      }
+
+      java.sql.Timestamp ts = new java.sql.Timestamp(value.getSeconds() * 1000);
+      ts.setNanos(value.getNanos());
+
+      return ts.getTime();
+    }
+
+    @Override
+    public Schema getRecommendedSchema() {
+      return LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+    }
+  }
+
+}

--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -20,6 +20,7 @@ package org.apache.avro.protobuf;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.IdentityHashMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -202,6 +203,12 @@ public class ProtobufData extends GenericData {
     if (seen.containsKey(descriptor))             // stop recursion
       return seen.get(descriptor);
     boolean first = seen.isEmpty();
+
+    Schema converted = schemaConversions.get(descriptor);
+    if (converted != null) {
+      return converted;
+    }
+
     try {
       Schema result =
         Schema.createRecord(descriptor.getName(), null,
@@ -350,6 +357,19 @@ public class ProtobufData extends GenericData {
       throw new RuntimeException("Unexpected type: "+f.getType());
     }
 
+  }
+
+  private Map<Descriptor, Schema> schemaConversions
+    = new HashMap<>();
+
+  /**
+   * Set proto descriptor -> avro schema conversion to handle logical type
+   *
+   * @param descriptor message descriptor in protobuf
+   * @param avroSchema avro schema might have logical type
+   */
+  public void addSchemaConversion(Descriptor descriptor, Schema avroSchema) {
+    schemaConversions.put(descriptor, avroSchema);
   }
 
 }

--- a/lang/java/protobuf/src/test/java/org/apache/avro/protobuf/TestProtoConversions.java
+++ b/lang/java/protobuf/src/test/java/org/apache/avro/protobuf/TestProtoConversions.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.protobuf;
+
+import com.google.protobuf.Timestamp;
+import org.apache.avro.Conversion;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.protobuf.ProtoConversions.*;
+import org.apache.avro.reflect.ReflectData;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Date;
+
+public class TestProtoConversions {
+
+  private static Schema TIMESTAMP_MILLIS_SCHEMA;
+  private static Schema TIMESTAMP_MICROS_SCHEMA;
+
+  @BeforeClass
+  public static void createSchemas() {
+    TestProtoConversions.TIMESTAMP_MILLIS_SCHEMA = LogicalTypes.timestampMillis()
+        .addToSchema(Schema.create(Schema.Type.LONG));
+    TestProtoConversions.TIMESTAMP_MICROS_SCHEMA = LogicalTypes.timestampMicros()
+        .addToSchema(Schema.create(Schema.Type.LONG));
+  }
+
+  @Test
+  public void testTimestampMillisConversion() throws Exception {
+    TimestampConversion conversion = new TimestampConversion();
+    long nowInstant = new Date().getTime();
+
+    Timestamp now = conversion.fromLong(
+        nowInstant, TIMESTAMP_MILLIS_SCHEMA, LogicalTypes.timestampMillis());
+    long roundTrip = conversion.toLong(
+        now, TIMESTAMP_MILLIS_SCHEMA, LogicalTypes.timestampMillis());
+    Assert.assertEquals("Round-trip conversion should work",
+        nowInstant, roundTrip);
+
+    long May_28_2015_21_46_53_221_instant = 1432849613221L;
+    Timestamp May_28_2015_21_46_53_221 = Timestamp.newBuilder()
+      .setSeconds(1432849613L)
+      .setNanos(221000000)
+      .build();
+
+    Assert.assertEquals("Known timestamp should be correct",
+        May_28_2015_21_46_53_221,
+        conversion.fromLong(May_28_2015_21_46_53_221_instant,
+            TIMESTAMP_MILLIS_SCHEMA, LogicalTypes.timestampMillis()));
+    Assert.assertEquals("Known timestamp should be correct",
+        May_28_2015_21_46_53_221_instant,
+        (long) conversion.toLong(May_28_2015_21_46_53_221,
+            TIMESTAMP_MILLIS_SCHEMA, LogicalTypes.timestampMillis()));
+  }
+
+  @Test
+  public void testTimestampMicrosConversion() throws Exception {
+    TimestampMicrosConversion conversion = new TimestampMicrosConversion();
+
+    long May_28_2015_21_46_53_221_843_instant = 1432849613221L * 1000 + 843;
+    Timestamp May_28_2015_21_46_53_221_843_ts = Timestamp.newBuilder()
+      .setSeconds(1432849613L)
+      .setNanos(221843000)
+      .build();
+
+    Assert.assertEquals("Known timestamp should be correct",
+        May_28_2015_21_46_53_221_843_ts,
+        conversion.fromLong(May_28_2015_21_46_53_221_843_instant,
+            TIMESTAMP_MICROS_SCHEMA, LogicalTypes.timestampMicros()));
+
+    try {
+      conversion.toLong(May_28_2015_21_46_53_221_843_ts,
+        TIMESTAMP_MICROS_SCHEMA, LogicalTypes.timestampMicros());
+      Assert.fail("Should not convert DateTime to long");
+    } catch (UnsupportedOperationException e) {
+      // expected
+    }
+  }
+
+  /*
+  model.addLogicalTypeConversion(new ProtoConversions.TimeMicrosConversion());
+  model.addLogicalTypeConversion(new ProtoConversions.TimestampMicrosConversion());
+ */
+  @Test
+  public void testDynamicSchemaWithDateTimeConversion() throws ClassNotFoundException {
+    Schema schema = getReflectedSchemaByName("com.google.protobuf.Timestamp", new TimestampConversion());
+    Assert.assertEquals("Reflected schema should be logicalType timestampMillis", TIMESTAMP_MILLIS_SCHEMA, schema);
+  }
+
+  @Test
+  public void testDynamicSchemaWithDateTimeMicrosConversion() throws ClassNotFoundException {
+    Schema schema = getReflectedSchemaByName("com.google.protobuf.Timestamp", new TimestampMicrosConversion());
+    Assert.assertEquals("Reflected schema should be logicalType timestampMicros", TIMESTAMP_MICROS_SCHEMA, schema);
+  }
+
+  private Schema getReflectedSchemaByName(String className, Conversion<?> conversion) throws ClassNotFoundException {
+    // one argument: a fully qualified class name
+    Class<?> cls = Class.forName(className);
+
+    // get the reflected schema for the given class
+    ReflectData model = new ReflectData();
+    model.addLogicalTypeConversion(conversion);
+    return model.getSchema(cls);
+  }
+
+}

--- a/lang/java/protobuf/src/test/java/org/apache/avro/protobuf/TestProtobuf.java
+++ b/lang/java/protobuf/src/test/java/org/apache/avro/protobuf/TestProtobuf.java
@@ -28,6 +28,7 @@ import org.apache.avro.specific.SpecificData;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import com.google.protobuf.ByteString;
 
@@ -92,5 +93,21 @@ public class TestProtobuf {
   @Test public void testNestedClassNamespace() throws Exception {
     Schema s = ProtobufData.get().getSchema(Foo.class);
     assertEquals(org.apache.avro.protobuf.Test.class.getName(), s.getNamespace());
+  }
+
+  @Test public void testGetNonRepeatedSchemaWithLogicalType() throws Exception {
+    ProtoConversions.TimestampConversion conversion = new ProtoConversions.TimestampConversion();
+
+    // Don't convert to logical type if conversion isn't set
+    ProtobufData instance1 = new ProtobufData();
+    Schema s1 = instance1.getSchema(com.google.protobuf.Timestamp.class);
+    assertNotEquals(conversion.getRecommendedSchema(), s1);
+
+    // Convert to logical type if conversion is set
+    ProtobufData instance2 = new ProtobufData();
+    instance2.addLogicalTypeConversion(conversion);
+    instance2.addSchemaConversion(com.google.protobuf.Timestamp.getDescriptor(), conversion.getRecommendedSchema());
+    Schema s2 = instance2.getSchema(com.google.protobuf.Timestamp.class);
+    assertEquals(conversion.getRecommendedSchema(), s2);
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-2344
to master > https://github.com/apache/avro/pull/482

Enable to handle `com.google.protobuf.Timestamp` as Logical Types in Avro.
It's handled by `org.apache.avro.Conversion` and we can specify whether using that by `addSchemaConversion()` and `addLogicalTypeConversion()`. This default behavior is non-conversion so it's compatible with current master.