### PR TITLE
Use jackson used in avro-1.8.2

### DIFF
--- a/lang/java/protobuf/pom.xml
+++ b/lang/java/protobuf/pom.xml
@@ -78,11 +78,12 @@
     </profile>
   </profiles>
 
+  <!-- For 1.8.2 compatibility -->
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>avro</artifactId>
-      <version>${project.version}</version>
+      <version>1.8.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -90,12 +91,14 @@
       <version>${protobuf.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>1.9.13</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.13</version>
     </dependency>
   </dependencies>
 

--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtoConversions.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtoConversions.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.avro.protobuf;
 
 import com.google.protobuf.Timestamp;

--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -31,7 +31,7 @@ import java.io.File;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.specific.SpecificData;
+import org.apache.avro.protobuf.compat18.Avro19ClassGetter;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DatumWriter;
 
@@ -46,11 +46,10 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.DescriptorProtos.FileOptions;
 
-import org.apache.avro.util.internal.Accessor;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.node.JsonNodeFactory;
 
 /** Utilities for serializing Protobuf data in Avro format. */
 public class ProtobufData extends GenericData {
@@ -135,7 +134,7 @@ public class ProtobufData extends GenericData {
   @Override
   public Object newRecord(Object old, Schema schema) {
     try {
-      Class c = SpecificData.get().getClass(schema);
+      Class c = Avro19ClassGetter.get().getClass(schema);
       if (c == null)
         return newRecord(old, schema);            // punt to generic
       if (c.isInstance(old))
@@ -220,7 +219,7 @@ public class ProtobufData extends GenericData {
 
       List<Field> fields = new ArrayList<>();
       for (FieldDescriptor f : descriptor.getFields())
-        fields.add(Accessor.createField(f.getName(), getSchema(f), null, getDefault(f)));
+        fields.add(new Field(f.getName(), getSchema(f), null, getDefault(f)));
       result.setFields(fields);
       return result;
 

--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufDatumReader.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufDatumReader.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.specific.SpecificData;
+import org.apache.avro.protobuf.compat18.Avro19ClassGetter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.ResolvingDecoder;
 
@@ -66,7 +66,7 @@ public class ProtobufDatumReader<T> extends GenericDatumReader<T> {
   @Override
   protected Object createEnum(String symbol, Schema schema) {
     try {
-      Class c = SpecificData.get().getClass(schema);
+      Class c = Avro19ClassGetter.get().getClass(schema);
       if (c == null) return super.createEnum(symbol, schema); // punt to generic
       return ((ProtocolMessageEnum)Enum.valueOf(c, symbol)).getValueDescriptor();
     } catch (Exception e) {

--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/compat18/Avro19ClassGetter.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/compat18/Avro19ClassGetter.java
@@ -1,0 +1,125 @@
+package org.apache.avro.protobuf.compat18;
+
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.util.ClassUtils;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.avro.generic.GenericData.STRING_PROP;
+
+/**
+ * Class getter from SpecificData in avro-1.9
+ * It enables avro-protobuf-1.9 not to depend on avro-1.9 to simplify dependency issue.
+ *
+ */
+public class Avro19ClassGetter {
+
+  private static final Avro19ClassGetter INSTANCE = new Avro19ClassGetter();
+  private static final Class NO_CLASS = new Object() {}.getClass();
+  private static final Schema NULL_SCHEMA = Schema.create(Schema.Type.NULL);
+  private static final String STRING_TYPE_STRING = "String";
+
+  public static Avro19ClassGetter get() {
+    return INSTANCE;
+  }
+
+  private Map<String, Class> classCache = new ConcurrentHashMap<>();
+
+  public ClassLoader getClassLoader() { return getClass().getClassLoader(); }
+
+  /**
+   * Return the class that implements a schema, or null if none exists.
+   */
+  public Class getClass(Schema schema) {
+    switch (schema.getType()) {
+      case FIXED:
+      case RECORD:
+      case ENUM:
+        String name = schema.getFullName();
+        if (name == null) return null;
+        Class c = classCache.get(name);
+        if (c == null) {
+          try {
+            c = ClassUtils.forName(getClassLoader(), getClassName(schema));
+          } catch (ClassNotFoundException e) {
+            try {                                   // nested class?
+              c = ClassUtils.forName(getClassLoader(), getNestedClassName(schema));
+            } catch (ClassNotFoundException ex) {
+              c = NO_CLASS;
+            }
+          }
+          classCache.put(name, c);
+        }
+        return c == NO_CLASS ? null : c;
+      case ARRAY:
+        return List.class;
+      case MAP:
+        return Map.class;
+      case UNION:
+        List<Schema> types = schema.getTypes();     // elide unions with null
+        if ((types.size() == 2) && types.contains(NULL_SCHEMA))
+          return getWrapper(types.get(types.get(0).equals(NULL_SCHEMA) ? 1 : 0));
+        return Object.class;
+      case STRING:
+        if (STRING_TYPE_STRING.equals(schema.getProp(STRING_PROP)))
+          return String.class;
+        return CharSequence.class;
+      case BYTES:
+        return ByteBuffer.class;
+      case INT:
+        return Integer.TYPE;
+      case LONG:
+        return Long.TYPE;
+      case FLOAT:
+        return Float.TYPE;
+      case DOUBLE:
+        return Double.TYPE;
+      case BOOLEAN:
+        return Boolean.TYPE;
+      case NULL:
+        return Void.TYPE;
+      default:
+        throw new AvroRuntimeException("Unknown type: " + schema);
+    }
+  }
+
+  private Class getWrapper(Schema schema) {
+    switch (schema.getType()) {
+      case INT:
+        return Integer.class;
+      case LONG:
+        return Long.class;
+      case FLOAT:
+        return Float.class;
+      case DOUBLE:
+        return Double.class;
+      case BOOLEAN:
+        return Boolean.class;
+    }
+    return getClass(schema);
+  }
+
+  /**
+   * Returns the Java class name indicated by a schema's name and namespace.
+   */
+  private String getClassName(Schema schema) {
+    String namespace = schema.getNamespace();
+    String name = schema.getName();
+    if (namespace == null || "".equals(namespace))
+      return name;
+    String dot = namespace.endsWith("$") ? "" : "."; // back-compatibly handle $
+    return namespace + dot + name;
+  }
+
+  private String getNestedClassName(Schema schema) {
+    String namespace = schema.getNamespace();
+    String name = schema.getName();
+    if (namespace == null || "".equals(namespace))
+      return name;
+    return namespace + "$" + name;
+  }
+}

--- a/lang/java/protobuf/src/test/java/org/apache/avro/protobuf/TestProtobuf.java
+++ b/lang/java/protobuf/src/test/java/org/apache/avro/protobuf/TestProtobuf.java
@@ -24,6 +24,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.protobuf.compat18.Avro19ClassGetter;
 import org.apache.avro.specific.SpecificData;
 
 import org.junit.Test;
@@ -88,7 +89,7 @@ public class TestProtobuf {
 
   @Test public void testNestedEnum() throws Exception {
     Schema s = ProtobufData.get().getSchema(M.N.class);
-    assertEquals(M.N.class.getName(), SpecificData.get().getClass(s).getName());
+    assertEquals(M.N.class.getName(), Avro19ClassGetter.get().getClass(s).getName());
   }
 
   @Test public void testNestedClassNamespace() throws Exception {


### PR DESCRIPTION
We need latest `avro-protobuf` changes without conflicting avro version issues injected by some other packages. As a workaround, we create our patched `avro-protobuf` with dependency on avro-1.8.2